### PR TITLE
Refine downtime alerts with confirmation retries

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -2,7 +2,7 @@ name: Website Uptime Monitor
 
 on:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 * * * *'
   push:
     branches: [ main ]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ und stellt die Ergebnisse über GitHub Pages bereit.
 
 ## Funktionsweise
 
-* Alle 2 Stunden startet ein GitHub&nbsp;Actions&nbsp;Workflow das
+* Jede Stunde startet ein GitHub&nbsp;Actions&nbsp;Workflow das
   Python‑Skript `src/monitor.py`.
 * Der aktuelle Status wird in `status.json` gespeichert und zusätzlich in
   `history.json` archiviert.
-* Bei zweimaligem Fehlschlag versucht `monitor.py` automatisch, ein GitHub-Issue anzulegen.
+* Bei `403` oder Transportfehlern prüft `monitor.py` nach 15 und 30 Minuten erneut.
+* Erst wenn alle drei Prüfungen fehlschlagen, versucht `monitor.py` automatisch, ein GitHub-Issue anzulegen.
 * Hierzu wird das Standard-Token `GITHUB_TOKEN` genutzt, das der Workflow mit den Rechten `contents: write` und `issues: write` bereitstellt.
 * Änderungen an diesen Dateien werden automatisch committet. Dadurch
   löst jeder Lauf eine Aktualisierung der GitHub&nbsp;Pages‑Seite aus.

--- a/index.html
+++ b/index.html
@@ -103,6 +103,8 @@
             const lastCheck = status.timestamp ? new Date(status.timestamp).toLocaleString('de-DE') : '-';
             const uptime = status.uptime || { uptime: '-', totalChecks: '-', onlineChecks: '-' };
             const errorMessage = status.error ? `<div style="color: #dc3545; margin-top: 10px;">Fehler: ${status.error}</div>` : '';
+            const details = status.message ? `<p><strong>Hinweis:</strong> <span>${status.message}</span></p>` : '';
+            const attemptInfo = status.attemptCount ? `<p><strong>Versuche:</strong> <span>${status.attemptCount}</span></p>` : '';
 
             return `
                 <div class="${cardClass}">
@@ -113,7 +115,9 @@
                     <p><strong>URL:</strong> <a class="url" href="${status.url}" target="_blank">${status.url}</a></p>
                     <p><strong>Status Code:</strong> <span>${status.statusCode || '-'}</span></p>
                     <p><strong>Antwortzeit:</strong> <span>${status.responseTime || '-'}</span> ms</p>
+                    ${attemptInfo}
                     <p><strong>Letzte Überprüfung:</strong> <span>${lastCheck}</span></p>
+                    ${details}
                     ${errorMessage}
                     <div class="metrics">
                         <div class="metric">

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
-import requests
 import json
 import os
-from datetime import datetime, timezone
 import time
-from github_issues import create_github_issue
+from datetime import datetime, timezone
+
+import requests
+
+try:
+    from .github_issues import create_github_issue
+except ImportError:
+    from github_issues import create_github_issue
 
 URLS_TO_CHECK = [
     'https://www.zentraleserien-hybridesuche.zh.ch',
@@ -13,98 +18,199 @@ URLS_TO_CHECK = [
 ]
 STATUS_FILE = os.path.join(os.path.dirname(__file__), '..', 'status.json')
 HISTORY_FILE = os.path.join(os.path.dirname(__file__), '..', 'history.json')
+REQUEST_HEADERS = {'User-Agent': 'Uptime-Monitor/1.0.0'}
+REQUEST_TIMEOUT_SECONDS = 30
+RETRY_DELAYS_SECONDS = (15 * 60, 15 * 60)
+MAX_HISTORY_RUNS = 1000
 
-def single_check(url):
-    start_time = time.time()
-    status = {
+
+def _transport_exception_type():
+    exceptions_module = getattr(requests, 'exceptions', None)
+    return getattr(exceptions_module, 'RequestException', Exception)
+
+
+def _is_transport_error(error):
+    return isinstance(error, _transport_exception_type())
+
+
+def _base_status(url):
+    return {
         'url': url,
         'timestamp': datetime.now(timezone.utc).isoformat(),
         'status': 'unknown',
         'responseTime': 0,
         'statusCode': 0,
-        'error': None
+        'error': None,
+        'attemptCount': 1,
+        'confirmedFailure': False,
+        'message': None,
     }
+
+
+def _finalize_status(status, final_status, attempt_count, confirmed_failure, message):
+    status['status'] = final_status
+    status['attemptCount'] = attempt_count
+    status['confirmedFailure'] = confirmed_failure
+    status['message'] = message
+    status.pop('_classification', None)
+    status.pop('_failureType', None)
+    return status
+
+
+def _classify_http_status(status_code):
+    if 200 <= status_code < 300:
+        return 'online', 'none'
+    if status_code == 403:
+        return 'retryable', '403'
+    return 'offline', 'http_status'
+
+
+def _classify_error(error):
+    if _is_transport_error(error):
+        return 'retryable', 'transport'
+    return 'offline', 'exception'
+
+
+def _direct_failure_message(status, phase='initial check'):
+    if status.get('_failureType') == 'http_status':
+        return f"HTTP {status['statusCode']} returned on {phase}"
+    if status.get('_failureType') == 'exception':
+        return f'Unexpected error during {phase}'
+    return 'Website is offline'
+
+
+def _confirmed_retry_failure_message(attempts):
+    failure_types = {attempt.get('_failureType') for attempt in attempts}
+    if failure_types == {'403'}:
+        return '403 persisted across 3 checks'
+    if failure_types == {'transport'}:
+        return 'Transport error persisted across 3 checks'
+    return 'Retryable failure persisted across 3 checks'
+
+
+def _recovery_message(attempt_count):
+    minutes = (attempt_count - 1) * 15
+    return f'Recovered on retry after {minutes} minutes'
+
+
+def single_check(url, request_get=requests.get):
+    start_time = time.time()
+    status = _base_status(url)
     try:
-        response = requests.get(
+        response = request_get(
             url,
-            timeout=30,
-            headers={'User-Agent': 'Uptime-Monitor/1.0.0'}
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            headers=REQUEST_HEADERS,
         )
-        end_time = time.time()
-        response_time = int((end_time - start_time) * 1000)
+        response_time = int((time.time() - start_time) * 1000)
+        classification, failure_type = _classify_http_status(response.status_code)
         status.update({
-            'status': 'online' if 200 <= response.status_code < 300 else 'offline',
             'responseTime': response_time,
-            'statusCode': response.status_code
+            'statusCode': response.status_code,
+            '_classification': classification,
+            '_failureType': failure_type,
         })
-        print(f"✅ Website is online - Status: {response.status_code} - Response time: {response_time}ms")
+        if classification == 'online':
+            print(f"✅ Website is online - Status: {response.status_code} - Response time: {response_time}ms")
+        elif classification == 'retryable':
+            print(f"⚠️ Website returned retryable status {response.status_code} - Response time: {response_time}ms")
+        else:
+            print(f"❌ Website is offline - Status: {response.status_code} - Response time: {response_time}ms")
     except Exception as error:
-        end_time = time.time()
-        response_time = int((end_time - start_time) * 1000)
+        response_time = int((time.time() - start_time) * 1000)
+        classification, failure_type = _classify_error(error)
         status.update({
-            'status': 'offline',
             'responseTime': response_time,
             'statusCode': 0,
-            'error': str(error)
+            'error': str(error),
+            '_classification': classification,
+            '_failureType': failure_type,
         })
-        print(f"❌ Website is offline - Error: {error}")
+        if classification == 'retryable':
+            print(f"⚠️ Retryable transport error: {error}")
+        else:
+            print(f"❌ Website is offline - Error: {error}")
     return status
 
-def check_url(url):
-    """Check if the website is online and return status information. Retry once if offline."""
-    print(f"Checking website: {url}")
-    status = single_check(url)
-    if status['status'] == 'offline':
-        print("Retrying after failure...")
-        time.sleep(5)
-        status = single_check(url)
-        if status['status'] == 'offline':
-            # Open GitHub issue if still offline
-            repo = os.environ.get('GITHUB_REPOSITORY', 'ruedtim/uptime')
-            token = os.environ.get('GITHUB_TOKEN')
-            if token:
-                title = f"Website DOWN: {url}"
-                body = f"Automatic alert: The website {url} is down as of {status['timestamp']}.\n\nError: {status['error']}\nStatus code: {status['statusCode']}"
-                create_github_issue(repo, title, body, token)
-            else:
-                print("⚠️ No GITHUB_TOKEN found in environment. Cannot create GitHub issue.")
-    return status
 
-def check_websites():
-    return [check_url(url) for url in URLS_TO_CHECK]
+def _maybe_create_issue(status):
+    if status.get('status') != 'offline' or not status.get('confirmedFailure'):
+        return
+
+    repo = os.environ.get('GITHUB_REPOSITORY', 'ruedtim/uptime')
+    token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        print('⚠️ No GITHUB_TOKEN found in environment. Cannot create GitHub issue.')
+        return
+
+    title = f"Website DOWN: {status['url']}"
+    body = (
+        f"Automatic alert: The website {status['url']} is down as of {status['timestamp']}.\n\n"
+        f"Message: {status.get('message')}\n"
+        f"Attempts: {status.get('attemptCount')}\n"
+        f"Error: {status.get('error')}\n"
+        f"Status code: {status.get('statusCode')}"
+    )
+    create_github_issue(repo, title, body, token)
+
+
+def check_url(url, sleep_fn=time.sleep, request_get=requests.get):
+    print(f'Checking website: {url}')
+    attempts = [single_check(url, request_get=request_get)]
+    first_attempt = attempts[0]
+
+    if first_attempt['_classification'] == 'online':
+        return _finalize_status(first_attempt, 'online', 1, False, None)
+
+    if first_attempt['_classification'] == 'offline':
+        final_status = _finalize_status(first_attempt, 'offline', 1, True, _direct_failure_message(first_attempt))
+        _maybe_create_issue(final_status)
+        return final_status
+
+    for attempt_count, delay_seconds in enumerate(RETRY_DELAYS_SECONDS, start=2):
+        print(f'Retrying in {delay_seconds // 60} minutes...')
+        sleep_fn(delay_seconds)
+        attempt = single_check(url, request_get=request_get)
+        attempts.append(attempt)
+
+        if attempt['_classification'] == 'online':
+            return _finalize_status(attempt, 'online', attempt_count, False, _recovery_message(attempt_count))
+
+        if attempt['_classification'] == 'offline':
+            final_status = _finalize_status(
+                attempt,
+                'offline',
+                attempt_count,
+                True,
+                _direct_failure_message(attempt, phase=f'retry attempt {attempt_count}'),
+            )
+            _maybe_create_issue(final_status)
+            return final_status
+
+    final_status = _finalize_status(
+        attempts[-1],
+        'offline',
+        len(attempts),
+        True,
+        _confirmed_retry_failure_message(attempts),
+    )
+    _maybe_create_issue(final_status)
+    return final_status
+
+
+def check_websites(sleep_fn=time.sleep, request_get=requests.get):
+    return [check_url(url, sleep_fn=sleep_fn, request_get=request_get) for url in URLS_TO_CHECK]
+
 
 def save_status(statuses):
-    """Save the current status to status.json"""
+    """Save the current status list to status.json."""
     try:
-        with open(STATUS_FILE, 'w') as f:
-            json.dump(statuses, f, indent=2)
+        with open(STATUS_FILE, 'w') as file_handle:
+            json.dump(statuses, file_handle, indent=2)
         print('Status saved to status.json')
     except Exception as error:
         print(f'Error saving status: {error}')
 
-def save_to_history(statuses):
-    """Save status to history.json"""
-    try:
-        history = []
-        
-        # Read existing history if file exists
-        if os.path.exists(HISTORY_FILE):
-            with open(HISTORY_FILE, 'r') as f:
-                history = json.load(f)
-        
-        # Add new status entries to history
-        history.extend(statuses)
-        
-        # Keep only last 1000 entries to prevent file from growing too large
-        if len(history) > 1000:
-            history = history[-1000:]
-        
-        with open(HISTORY_FILE, 'w') as f:
-            json.dump(history, f, indent=2)
-        print('Status added to history.json')
-        
-    except Exception as error:
-        print(f'Error saving to history: {error}')
 
 def _iter_history_entries(history):
     for entry in history:
@@ -119,48 +225,76 @@ def _iter_history_entries(history):
                 if isinstance(item, dict) and 'url' in item:
                     yield item
 
+
+def _trim_history_entries(history):
+    max_entries = MAX_HISTORY_RUNS * max(len(URLS_TO_CHECK), 1)
+    if len(history) <= max_entries:
+        return history
+    return history[-max_entries:]
+
+
+def save_to_history(statuses):
+    """Save status to history.json."""
+    try:
+        history = []
+        if os.path.exists(HISTORY_FILE):
+            with open(HISTORY_FILE, 'r') as file_handle:
+                history = json.load(file_handle)
+
+        history.extend(statuses)
+        history = _trim_history_entries(history)
+
+        with open(HISTORY_FILE, 'w') as file_handle:
+            json.dump(history, file_handle, indent=2)
+        print('Status added to history.json')
+    except Exception as error:
+        print(f'Error saving to history: {error}')
+
+
 def calculate_uptime(url=None):
-    """Calculate uptime statistics from history"""
+    """Calculate uptime statistics from history."""
     try:
         if not os.path.exists(HISTORY_FILE):
             return {'uptime': '0', 'totalChecks': 0, 'onlineChecks': 0}
-        
-        with open(HISTORY_FILE, 'r') as f:
-            history = json.load(f)
+
+        with open(HISTORY_FILE, 'r') as file_handle:
+            history = json.load(file_handle)
 
         entries = [entry for entry in _iter_history_entries(history) if url is None or entry.get('url') == url]
         total_checks = len(entries)
         online_checks = sum(1 for check in entries if check.get('status') == 'online')
         uptime = (online_checks / total_checks) * 100 if total_checks > 0 else 0
-        
+
         return {
-            'uptime': f"{uptime:.2f}",
+            'uptime': f'{uptime:.2f}',
             'totalChecks': total_checks,
-            'onlineChecks': online_checks
+            'onlineChecks': online_checks,
         }
-        
     except Exception as error:
         print(f'Error calculating uptime: {error}')
         return {'uptime': '0', 'totalChecks': 0, 'onlineChecks': 0}
 
+
 def main():
-    """Main function to run the uptime check"""
+    """Main function to run the uptime check."""
     print('Starting uptime check...')
-    
+
     statuses = check_websites()
-    
     save_to_history(statuses)
 
-    # Add uptime statistics to each status (after history update)
     for status in statuses:
         status['uptime'] = calculate_uptime(status.get('url'))
-    
+
     save_status(statuses)
-    
+
     for status in statuses:
         uptime_stats = status.get('uptime', {})
-        print(f"Uptime for {status.get('url')}: {uptime_stats.get('uptime', '0')}% ({uptime_stats.get('onlineChecks', 0)}/{uptime_stats.get('totalChecks', 0)} checks)")
+        print(
+            f"Uptime for {status.get('url')}: {uptime_stats.get('uptime', '0')}% "
+            f"({uptime_stats.get('onlineChecks', 0)}/{uptime_stats.get('totalChecks', 0)} checks)"
+        )
     print('Uptime check completed!')
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,175 @@
+import importlib
+import sys
+import types
+import unittest
+from collections import Counter
+from unittest.mock import patch
+
+
+fake_requests = types.ModuleType('requests')
+
+
+class RequestException(Exception):
+    pass
+
+
+def _unused_request(*args, **kwargs):
+    raise AssertionError('Unexpected real network call during tests')
+
+
+fake_requests.exceptions = types.SimpleNamespace(RequestException=RequestException)
+fake_requests.get = _unused_request
+fake_requests.post = _unused_request
+sys.modules.setdefault('requests', fake_requests)
+
+monitor = importlib.import_module('src.monitor')
+
+
+class Response:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class TransportError(RequestException):
+    pass
+
+
+def sequence_request(results):
+    items = list(results)
+
+    def request_get(url, timeout, headers):
+        if not items:
+            raise AssertionError('No more test responses available')
+        next_item = items.pop(0)
+        if isinstance(next_item, Exception):
+            raise next_item
+        return next_item
+
+    return request_get
+
+
+class MonitorTests(unittest.TestCase):
+    def test_online_on_first_success(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([Response(200)]),
+            )
+
+        self.assertEqual(status['status'], 'online')
+        self.assertEqual(status['attemptCount'], 1)
+        self.assertFalse(status['confirmedFailure'])
+        self.assertIsNone(status['message'])
+        self.assertEqual(sleep_calls, [])
+        issue_mock.assert_not_called()
+
+    def test_403_recovers_on_second_attempt(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([Response(403), Response(200)]),
+            )
+
+        self.assertEqual(status['status'], 'online')
+        self.assertEqual(status['attemptCount'], 2)
+        self.assertEqual(status['message'], 'Recovered on retry after 15 minutes')
+        self.assertEqual(sleep_calls, [900])
+        issue_mock.assert_not_called()
+
+    def test_403_three_times_confirms_offline(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([Response(403), Response(403), Response(403)]),
+            )
+
+        self.assertEqual(status['status'], 'offline')
+        self.assertEqual(status['attemptCount'], 3)
+        self.assertTrue(status['confirmedFailure'])
+        self.assertEqual(status['message'], '403 persisted across 3 checks')
+        self.assertEqual(sleep_calls, [900, 900])
+        issue_mock.assert_called_once_with(status)
+
+    def test_transport_error_recovers_on_third_attempt(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([
+                    TransportError('network down'),
+                    TransportError('network down'),
+                    Response(200),
+                ]),
+            )
+
+        self.assertEqual(status['status'], 'online')
+        self.assertEqual(status['attemptCount'], 3)
+        self.assertEqual(status['message'], 'Recovered on retry after 30 minutes')
+        self.assertEqual(sleep_calls, [900, 900])
+        issue_mock.assert_not_called()
+
+    def test_transport_error_three_times_confirms_offline(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([
+                    TransportError('network down'),
+                    TransportError('network down'),
+                    TransportError('still down'),
+                ]),
+            )
+
+        self.assertEqual(status['status'], 'offline')
+        self.assertEqual(status['attemptCount'], 3)
+        self.assertTrue(status['confirmedFailure'])
+        self.assertEqual(status['message'], 'Transport error persisted across 3 checks')
+        self.assertEqual(sleep_calls, [900, 900])
+        issue_mock.assert_called_once_with(status)
+
+    def test_non_retryable_http_error_is_immediately_offline(self):
+        sleep_calls = []
+
+        with patch.object(monitor, '_maybe_create_issue') as issue_mock:
+            status = monitor.check_url(
+                'https://example.com',
+                sleep_fn=sleep_calls.append,
+                request_get=sequence_request([Response(500)]),
+            )
+
+        self.assertEqual(status['status'], 'offline')
+        self.assertEqual(status['attemptCount'], 1)
+        self.assertTrue(status['confirmedFailure'])
+        self.assertEqual(status['message'], 'HTTP 500 returned on initial check')
+        self.assertEqual(sleep_calls, [])
+        issue_mock.assert_called_once_with(status)
+
+    def test_trim_history_keeps_both_urls(self):
+        history = []
+        for run_number in range(monitor.MAX_HISTORY_RUNS + 1):
+            for url in monitor.URLS_TO_CHECK:
+                history.append({'url': url, 'status': 'online', 'run': run_number})
+
+        trimmed = monitor._trim_history_entries(history)
+
+        self.assertEqual(len(trimmed), monitor.MAX_HISTORY_RUNS * len(monitor.URLS_TO_CHECK))
+        counts = Counter(entry['url'] for entry in trimmed)
+        for url in monitor.URLS_TO_CHECK:
+            self.assertEqual(counts[url], monitor.MAX_HISTORY_RUNS)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Summary
- switch the monitor to hourly runs and keep the retry policy so 403 / transport errors trigger two 15-minute follow-ups before declaring offline
- add richer status metadata (attemptCount, confirmedFailure, message) and surface it on the site, while trimming history by run count
- tighten issue creation to confirmed failures and ensure the watcher workflow runs every hour

Testing
- Not run (not requested)